### PR TITLE
Upgrade to Spring Boot 3.3.0-M3 for CDS-friendly extract

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.samples</groupId>
   <artifactId>spring-petclinic</artifactId>
-  <version>3.2.0-SNAPSHOT</version>
+  <version>3.3.0-SNAPSHOT</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.1</version>
+    <version>3.3.0-M3</version>
   </parent>
   <name>petclinic</name>
 


### PR DESCRIPTION
This commit upgrades to Spring Boot 3.3.0-M3 which provides a new way to extract a Spring Boot application.

To benefit from this feature, run "./mvw pacakge" as usual. The application can be extracted with the following command:

java -Djarmode=tools -jar target/spring-petclinic-3.3.0-SNAPSHOT.jar extract --destination target/app

This creates a "target/app" directory with the following structure

target/app
├── lib
│   ├── spring-boot-3.3.0-M3.jar
│   ├── spring-boot-actuator-3.3.0-M3.jar
│   ├── spring-boot-actuator-autoconfigure-3.3.0-M3.jar │   ├── spring-boot-autoconfigure-3.3.0-M3.jar
│   ├── spring-boot-jarmode-tools-3.3.0-M3.jar
│   ├── spring-context-6.1.5.jar
│   ├── spring-context-support-6.1.5.jar
│   ├── spring-core-6.1.5.jar
│   ...
└── spring-petclinic-3.3.0-SNAPSHOT.jar

The application can be started as follows:

java -jar target/app/spring-petclinic-3.3.0-SNAPSHOT.jar